### PR TITLE
feat(format_log_for_upload): reset/clear the input compat log txt fil…

### DIFF
--- a/format_log_for_upload.py
+++ b/format_log_for_upload.py
@@ -155,7 +155,7 @@ def replace_instances(player_name, filename):
     ignored_pet_names = {"Razorgore the Untamed", "Deathknight Understudy", "Naxxramas Worshipper"}
 
     # associate common summoned pets with their owners as well
-    summoned_pet_names = {"Greater Feral Spirit", "Battle Chicken", "Arcanite Dragonling", "The Lost", "Minor Arcane Elemental",}
+    summoned_pet_names = {"Greater Feral Spirit", "Battle Chicken", "Arcanite Dragonling", "The Lost", "Minor Arcane Elemental", "Scytheclaw Pureborn"}
     summoned_pet_owner_regex = r"([a-zA-Z][ a-zA-Z]+[a-zA-Z]) \(([a-zA-Z]+)\)"
 
     for i, _ in enumerate(lines):

--- a/format_log_for_upload.py
+++ b/format_log_for_upload.py
@@ -155,7 +155,7 @@ def replace_instances(player_name, filename):
     ignored_pet_names = {"Razorgore the Untamed", "Deathknight Understudy", "Naxxramas Worshipper"}
 
     # associate common summoned pets with their owners as well
-    summoned_pet_names = {"Greater Feral Spirit", "Battle Chicken", "Arcanite Dragonling", "The Lost", "Minor Arcane Elemental", "Scytheclaw Pureborn"}
+    summoned_pet_names = {"Greater Feral Spirit", "Battle Chicken", "Arcanite Dragonling", "The Lost", "Minor Arcane Elemental",}
     summoned_pet_owner_regex = r"([a-zA-Z][ a-zA-Z]+[a-zA-Z]) \(([a-zA-Z]+)\)"
 
     for i, _ in enumerate(lines):
@@ -261,9 +261,16 @@ def replace_instances(player_name, filename):
 
 
 def create_zip_file(source_file, zip_filename):
-    with zipfile.ZipFile(zip_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:        zipf.write(source_file,
-                                                                                             arcname=os.path.basename(
-                                                                                                 source_file))
+    with zipfile.ZipFile(zip_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        zipf.write(
+            source_file,
+            arcname=os.path.basename(source_file)
+        )
+
+
+def reset_file(log_file_name):
+    with open(log_file_name, 'w', encoding='utf-8') as file:
+        file.write('')
 
 
 player_name = input("Enter player name: ")
@@ -278,3 +285,8 @@ if not create_zip.strip() or create_zip.lower().startswith('y'):
     create_zip_file(filename, filename + ".zip")
 print(
     f"Messages with You/Your have been converted to {player_name}.  A backup of the original file has also been created.")
+
+# Clear original log
+clear_log = input('Reset original log file (default y): ')
+if not clear_log.strip() or clear_log.lower().startswith('y'):
+    reset_file()

--- a/format_log_for_upload.py
+++ b/format_log_for_upload.py
@@ -283,10 +283,9 @@ create_zip = input("Create zip file (default y): ")
 replace_instances(player_name, filename)
 if not create_zip.strip() or create_zip.lower().startswith('y'):
     create_zip_file(filename, filename + ".zip")
+    # Clear original log
+    clear_log = input('Reset original log file (default y): ')
+    if not clear_log.strip() or clear_log.lower().startswith('y'):
+        reset_file()
 print(
     f"Messages with You/Your have been converted to {player_name}.  A backup of the original file has also been created.")
-
-# Clear original log
-clear_log = input('Reset original log file (default y): ')
-if not clear_log.strip() or clear_log.lower().startswith('y'):
-    reset_file()


### PR DESCRIPTION
# Description

This PR introduces a minor changes to `format_log_for_upload.py`, adding an option for users to automatically empty the original combat log file (`WoWCombatLog.txt`) after the script has successfully completed.

## Problem

By default, `WoWCombatLog.txt` is continuously appended to during multiple raid sessions. However, the script does not differentiate between individual raid instances. As a result, if the user formats and uploads logs after one raid session and then logs another session without clearing the file, the next formatted output will contain logs from both sessions

## Solution

With these changes, `format_log_for_upload.py` will automatically clear the specified log file (after prompting for permission) once it has been successfully formatted and a zipped version has been created. This helps prevent mixed log data across sessions. There's no risk of data loss, as a backup is always created before clearing the file.