### PR TITLE
Add shebang to python script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /core - Copy.lua
 /archive
+/__pycache__/
 *.txt
 *.zip
 *.exe

--- a/format_log_for_upload.py
+++ b/format_log_for_upload.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import os
 import re
 import shutil

--- a/run_format_log.sh
+++ b/run_format_log.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd "$(dirname "$0")"
-python format_log_for_upload.py


### PR DESCRIPTION
Removes the need for a wrapper on Unix-like systems.