### PR TITLE
revert change to remove raw 'CAST' writes

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -916,6 +916,10 @@ local fmt_with_rank_target = "CAST: %s %s %s(%s)(%s) on %s."
 local fmt_with_rank = "CAST: %s %s %s(%s)(%s)."
 local fmt_with_target = "CAST: %s %s %s(%s) on %s."
 local fmt_simple = "CAST: %s %s %s(%s)."
+local fmt_raw_with_rank_target = "CAST: %s(%s) %s %s(%s)(%s) on %s(%s)."
+local fmt_raw_with_rank = "CAST: %s(%s) %s %s(%s)(%s)."
+local fmt_raw_with_target = "CAST: %s(%s) %s %s(%s) on %s(%s)."
+local fmt_raw_simple = "CAST: %s(%s) %s %s(%s)."
 
 local function LogCastEventV2(caster, target, event, spellID, castDuration)
 	if not (caster and spellID) then return end
@@ -963,14 +967,18 @@ local function LogCastEventV2(caster, target, event, spellID, castDuration)
 	if targetName then
 		if rank ~= "" then
 			CombatLogAdd(format(fmt_with_rank_target, casterName, verb, spell, spellID, rank, targetName))
+			CombatLogAdd(format(fmt_raw_with_rank_target, caster, casterName, verb, spell, spellID, rank, target, targetName), 1)
 		else
 			CombatLogAdd(format(fmt_with_target, casterName, verb, spell, spellID, targetName))
+			CombatLogAdd(format(fmt_raw_with_target, caster, casterName, verb, spell, spellID, target, targetName), 1)
 		end
 	else
 		if rank ~= "" then
 			CombatLogAdd(format(fmt_with_rank, casterName, verb, spell, spellID, rank))
+			CombatLogAdd(format(fmt_raw_with_rank, caster, casterName, verb, spell, spellID, rank), 1)
 		else
 			CombatLogAdd(format(fmt_simple, casterName, verb, spell, spellID))
+			CombatLogAdd(format(fmt_raw_simple, caster, casterName, verb, spell, spellID), 1)
 		end
 	end
 end


### PR DESCRIPTION
@pepopo978 is there a reason this was removed?

I am using the raw combat log for my log parsing site (not finished yet). 

I was hoping to use these log lines. :smile: 
I noticed they were gone recently when trying to parse for them.