### PR TITLE
Improve SWCL logging accuracy while preserving legacy formatter output

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -23,6 +23,7 @@ RPLL.NUM_PLAYERS_IN_COMBAT = 0
 
 RPLL.PlayerInformation = {}
 RPLL.LoggedCombatantInfo = {}
+RPLL.GuidNameCache = {}
 
 RPLL:RegisterEvent("RAID_ROSTER_UPDATE")
 RPLL:RegisterEvent("PARTY_MEMBERS_CHANGED")
@@ -58,7 +59,10 @@ local pairs = pairs
 local GetNumPartyMembers = GetNumPartyMembers
 local GetNumRaidMembers = GetNumRaidMembers
 local UnitIsPlayer = UnitIsPlayer
+local UnitClass = UnitClass
+local UnitRace = UnitRace
 local UnitSex = UnitSex
+local UnitExists = UnitExists
 local strlower = strlower
 local GetGuildInfo = GetGuildInfo
 local GetInventoryItemLink = GetInventoryItemLink
@@ -66,8 +70,10 @@ local strfind = string.find
 local Unknown = UNKNOWN
 local LoggingCombat = LoggingCombat
 local time = time
+local GetTime = GetTime
 local GetRealZoneText = GetRealZoneText
 local date = date
+local format = string.format
 local strjoin = string.join or function(delim, ...)
 	if type(arg) == 'table' then
 		return table.concat(arg, delim)
@@ -100,6 +106,53 @@ local specials_data = {
 	-- }
 }
 
+local function NormalizeZoneName(name)
+	if not name or name == "" then
+		return nil, nil
+	end
+
+	name = string.gsub(name, "\226\128\152", "'")
+	name = string.gsub(name, "\226\128\153", "'")
+	name = string.gsub(name, "\194\160", " ")
+	name = string.gsub(name, "^%s+", "")
+	name = string.gsub(name, "%s+$", "")
+	if name == "" then
+		return nil, nil
+	end
+
+	return strlower(name), name
+end
+
+local ZONE_INFO_ALIASES = {
+	["Ahn'Qiraj Temple"] = "Temple of Ahn'Qiraj",
+	["Ahn Qiraj Temple"] = "Temple of Ahn'Qiraj",
+	["Temple of Ahn Qiraj"] = "Temple of Ahn'Qiraj",
+	["Ahn'Qiraj"] = "Temple of Ahn'Qiraj",
+	["Ahn Qiraj"] = "Temple of Ahn'Qiraj",
+	["Ahn'Qiraj Ruins"] = "Ruins of Ahn'Qiraj",
+	["Ahn Qiraj Ruins"] = "Ruins of Ahn'Qiraj",
+	["Ruins of Ahn Qiraj"] = "Ruins of Ahn'Qiraj",
+}
+
+local function CanonicalizeZoneName(name)
+	local zoneKey, zoneText = NormalizeZoneName(name)
+	if not zoneKey then
+		return nil, nil
+	end
+
+	local canonicalText = ZONE_INFO_ALIASES[zoneText] or zoneText
+	return NormalizeZoneName(canonicalText)
+end
+
+local function UpdateSpecialTargetsForZone()
+	local _, zoneText = CanonicalizeZoneName(GetRealZoneText())
+	if zoneText then
+		specials = specials_data[zoneText]
+	else
+		specials = nil
+	end
+end
+
 local function strsplit(pString, pPattern)
 	local Table = {}
 	local fpat = "(.-)" .. pPattern
@@ -113,7 +166,7 @@ local function strsplit(pString, pPattern)
 		s, e, cap = strfind(pString, fpat, last_end)
 	end
 	if last_end <= strlen(pString) then
-		cap = strfind(pString, last_end)
+		cap = strsub(pString, last_end)
 		table.insert(Table, cap)
 	end
 	return Table
@@ -375,7 +428,7 @@ local trackedConsumes = {
 	--[25990] = "Delicious Birthday Cake",
 	[25990] = "Graccus Mince Meat Fruitcake",  -- also avoids 's
 
-	[1127] = "Graccus Homemade Meat Pie",  -- also avoids 's, low level
+	[1127] = "Graccu's Homemade Meat Pie",
 
 	--[435] = "Clam Chowder",
 	--[435] = "Tigule and Foror's Strawberry Ice Cream",
@@ -389,13 +442,13 @@ local trackedConsumes = {
 
 
 	-- renames to remove 's and other special syntax
-	[10667] = "Rage of Ages",
-	[57106] = "Medivhs Merlot",
-	[57107] = "Medivhs Merlot Blue Label",
-	[22790] = "Kreegs Stout Beatdown",
-	[57043] = "Danonzos Tel'Abim Delight",
-	[57045] = "Danonzos Tel'Abim Medley",
-	[57055] = "Danonzos Tel'Abim Surprise",
+	[10667] = "R.O.I.D.S.",
+	[57106] = "Medivh's Merlot",
+	[57107] = "Medivh's Merlot Blue",
+	[22790] = "Kreeg's Stout Beatdown",
+	[57043] = "Danonzo's Tel'Abim Delight",
+	[57045] = "Danonzo's Tel'Abim Medley",
+	[57055] = "Danonzo's Tel'Abim Surprise",
 }
 
 -- auto generated, manually add stuff in trackedConsumes instead
@@ -861,6 +914,93 @@ for key, val in pairs(dbConsumes) do
   end
 end
 
+local AMBIGUOUS_CONSUME_SPELLS = {
+	[10256] = true,
+	[10257] = true,
+	[1127] = true,
+	[1129] = true,
+	[1131] = true,
+	[11319] = true,
+	[1133] = true,
+	[1135] = true,
+	[1137] = true,
+	[17038] = true,
+	[17530] = true,
+	[17531] = true,
+	[17534] = true,
+	[17545] = true,
+	[18229] = true,
+	[18230] = true,
+	[19199] = true,
+	[22731] = true,
+	[24005] = true,
+	[24355] = true,
+	[24382] = true,
+	[24383] = true,
+	[24417] = true,
+	[24707] = true,
+	[24800] = true,
+	[24869] = true,
+	[25660] = true,
+	[25990] = true,
+	[2639] = true,
+	[29008] = true,
+	[29073] = true,
+	[4042] = true,
+	[430] = true,
+	[431] = true,
+	[432] = true,
+	[433] = true,
+	[434] = true,
+	[435] = true,
+	[438] = true,
+	[440] = true,
+	[45024] = true,
+	[45427] = true,
+	[45489] = true,
+	[5004] = true,
+	[5005] = true,
+	[5006] = true,
+	[5007] = true,
+	[673] = true,
+	[7396] = true,
+	[7737] = true,
+}
+
+local function ResolveTrackedLabel(spellID)
+	local trackedSpell = trackedSpells[spellID]
+	if trackedSpell then
+		return trackedSpell, false
+	end
+
+	local trackedConsume = trackedConsumes[spellID]
+	if not trackedConsume then
+		return nil, false
+	end
+
+	if AMBIGUOUS_CONSUME_SPELLS[spellID] then
+		return "Ambiguous Consumable (" .. tostring(spellID) .. ")", true
+	end
+
+	return trackedConsume, true
+end
+
+local function BuildRaidRosterSignature()
+	local count = GetNumRaidMembers()
+	if count == 0 then
+		return ""
+	end
+
+	local parts = {}
+	for i = 1, count do
+		local unit = "raid" .. i
+		local _, guid = UnitExists(unit)
+		parts[#parts + 1] = guid or UnitName(unit) or "nil"
+	end
+
+	return table.concat(parts, "|")
+end
+
 local function logPlayersInCombat()
 	local currentPlayersInCombat = 0
 	local totalPlayers = 0
@@ -918,7 +1058,7 @@ RPLL.PLAYER_REGEN_ENABLED = function()
 end
 
 RPLL.UNIT_DIED = function(guid)
-	local name = UnitName(guid) or "Unknown"
+	local name = RPLL.GuidNameCache[guid] or UnitName(guid) or "Unknown"
 	CombatLogAdd("UNIT_DIED:" .. name .. ":" .. guid)
 end
 
@@ -929,25 +1069,25 @@ local fmt_with_target = "CAST: %s %s %s(%s) on %s."
 local fmt_simple = "CAST: %s %s %s(%s)."
 
 local function LogCastEventV2(caster, target, event, spellID, castDuration)
-	if not (caster and spellID) then return end
-	if event == "MAINHAND" or event == "OFFHAND" then return end
+	if not (caster and spellID) then return false end
+	if event == "MAINHAND" or event == "OFFHAND" then return false end
 
 	-- cache lookup
 	local cachedSpell = spellCache[spellID]
 	local spell = cachedSpell and cachedSpell[1]
-	local rank = cachedSpell and cachedSpell[2]
+	local rank = cachedSpell and cachedSpell[2] or ""
 
 	if not spell then
 		-- Spell not cached yet? Call SpellInfo and cache the result.
 		spell,rank = SpellInfo(spellID)
 		if spell then
 			-- only cache Rank for things that have one. Some items have joke ranks!
-			rank = string.find(rank, "^Rank") and rank or ""
+			rank = rank and string.find(rank, "^Rank") and rank or ""
 			spellCache[spellID] = { spell, rank }
 		end
 	end
 
-	if not spell then return end
+	if not spell then return false end
 
 	local targetName -- = UnitName(target) or "Unknown"
 	local casterName = UnitName(caster) or "Unknown"
@@ -984,21 +1124,19 @@ local function LogCastEventV2(caster, target, event, spellID, castDuration)
 			CombatLogAdd(format(fmt_simple, casterName, verb, spell, spellID))
 		end
 	end
+
+	return true
 end
 
 -- kept for backwards compatibility with existing tools
 local function LogCastEventV1(caster, target, event, spellID, castDuration)
-	if not (trackedSpells[spellID] or trackedConsumes[spellID]) then
-		return
-	end
-
 	if event ~= "CAST" then
-		return
+		return false
 	end
 
-	local spell = trackedSpells[spellID] or trackedConsumes[spellID]
+	local spell, isConsume = ResolveTrackedLabel(spellID)
 	if not spell then
-		return
+		return false
 	end
 
 	local casterName = UnitName(caster) --get name from GUID
@@ -1008,21 +1146,26 @@ local function LogCastEventV1(caster, target, event, spellID, castDuration)
 		casterName = "Unknown" -- can happen before player name is queried from server
 	end
 
-	local verb = trackedConsumes[spellID] and " uses " or " casts "
+	local verb = isConsume and " uses " or " casts "
 	if targetName then
 		CombatLogAdd(casterName .. verb .. spell .. " on " .. targetName .. ".")
 	else
 		CombatLogAdd(casterName .. verb .. spell .. ".")
 	end
+
+	return true
 end
 
 RPLL.UNIT_CASTEVENT = function(caster, target, event, spellID, castDuration)
+	if LogCastEventV2(caster, target, event, spellID, castDuration) then
+		return
+	end
 	LogCastEventV1(caster, target, event, spellID, castDuration) -- for backwards compatibility
-	LogCastEventV2(caster, target, event, spellID, castDuration)
 end
 
 RPLL.ZONE_CHANGED_NEW_AREA = function()
 	LoggingCombat(IsInInstance("player"))
+	UpdateSpecialTargetsForZone()
 	this:grab_unit_information("player")
 	this:RAID_ROSTER_UPDATE()
 	this:PARTY_MEMBERS_CHANGED()
@@ -1032,6 +1175,7 @@ end
 
 RPLL.UPDATE_INSTANCE_INFO = function()
 	LoggingCombat(IsInInstance("player"))
+	UpdateSpecialTargetsForZone()
 	this:grab_unit_information("player")
 	this:RAID_ROSTER_UPDATE()
 	this:PARTY_MEMBERS_CHANGED()
@@ -1054,23 +1198,25 @@ RPLL.PLAYER_ENTERING_WORLD = function()
   -- Rate limiting cache for player info scanning (timestamps only, session-only)
   this.PlayerInformation = {}
 
+	UpdateSpecialTargetsForZone()
 	this:grab_unit_information("player")
 	this:RAID_ROSTER_UPDATE()
 	this:PARTY_MEMBERS_CHANGED()
 end
 
-local rcount = 0
+local lastRaidRosterSignature = nil
 RPLL.RAID_ROSTER_UPDATE = function()
-	local rnow = GetNumRaidMembers()
-	if rnow == rcount then
+	local rosterSignature = BuildRaidRosterSignature()
+	if rosterSignature == lastRaidRosterSignature then
 		return
 	end
+	local rnow = GetNumRaidMembers()
 	for i = 1, rnow do
 		if UnitName("raid" .. i) then
 			this:grab_unit_information("raid" .. i)
 		end
 	end
-	rcount = rnow
+	lastRaidRosterSignature = rosterSignature
 end
 
 local pcount = 0
@@ -1104,7 +1250,7 @@ end
 
 RPLL.CHAT_MSG_SYSTEM = function(msg)
 	-- "Iseut trades item Libram of the Faithful to Milkpress."
-	local trade = string.find(msg, "^%w+ trades item")
+	local trade = string.find(msg, " trades item ", 1, true)
 	if trade then
 		CombatLogAdd("LOOT_TRADE: " .. date("%d.%m.%y %H:%M:%S") .. "&" .. msg)
 	end
@@ -1137,33 +1283,35 @@ function RPLL:QueueRaidIds()
 		return
 	end
 
-	local zone = strlower(GetRealZoneText())
+	local zoneKey, zoneText = CanonicalizeZoneName(GetRealZoneText())
 	local found = false
 	for i = 1, GetNumSavedInstances() do
 		local instance_name, instance_id = GetSavedInstanceInfo(i)
-		if zone == strlower(instance_name) then
+		local instanceKey = CanonicalizeZoneName(instance_name)
+		if zoneKey and zoneKey == instanceKey then
 			CombatLogAdd("ZONE_INFO: " .. date("%d.%m.%y %H:%M:%S") .. "&" .. instance_name .. "&" .. instance_id)
 			found = true
 			break
 		end
 	end
 
-	if found == false then
-		CombatLogAdd("ZONE_INFO: " .. date("%d.%m.%y %H:%M:%S") .. "&" .. zone .. "&0")
+	if found == false and zoneText then
+		CombatLogAdd("ZONE_INFO: " .. date("%d.%m.%y %H:%M:%S") .. "&" .. zoneText .. "&0")
 	end
 end
 
 function RPLL:grab_unit_information(unit)
 	local unit_name = UnitName(unit)
 	if UnitIsPlayer(unit) and unit_name ~= nil and unit_name ~= Unknown then
-    -- Check rate limiting using simple timestamp cache
-    local last_update = this.PlayerInformation[unit_name]
-    if last_update ~= nil and time() - last_update <= 30 then
+		-- Check rate limiting using simple timestamp cache
+		local now = time()
+		local last_update = this.PlayerInformation[unit_name]
+		if last_update ~= nil and now - last_update <= 30 then
 			return
 		end
 
-    -- Gather all info into local table
-    local info = {}
+		-- Gather all info into local table
+		local info = {}
 		info["last_update_date"] = date("%d.%m.%y %H:%M:%S")
 		info["name"] = unit_name
 
@@ -1264,12 +1412,13 @@ function RPLL:grab_unit_information(unit)
 		local exists, guid = UnitExists(unit)
 		if exists and guid then
 			info["guid"] = guid
+			RPLL.GuidNameCache[guid] = unit_name
 		end
 
-    -- Update timestamp cache
-    this.PlayerInformation[unit_name] = time()
-
-		log_combatant_info(info)
+		if log_combatant_info(info) then
+			-- Rate limiting only after we have a usable character snapshot.
+			this.PlayerInformation[unit_name] = now
+		end
 	end
 end
 
@@ -1291,7 +1440,7 @@ function log_combatant_info(character)
 
 		-- If all gear is nil, don't log
 		if num_nil_gear == 19 then
-			return
+			return false
 		end
 
 		local result = prep_value(character["name"]) .. "&"
@@ -1312,8 +1461,9 @@ function log_combatant_info(character)
 			CombatLogAdd(result_prefix .. result)
 			RPLL.LoggedCombatantInfo[result] = true
 		end
-
+		return true
 	end
+	return false
 end
 
 function prep_value(val)

--- a/core.lua
+++ b/core.lua
@@ -441,7 +441,9 @@ local trackedConsumes = {
 	[1129] = "Crunchy Frog",  -- also avoids 's, low level
 
 
-	-- renames to remove 's and other special syntax
+	-- Keep exact punctuation for unique item names. Ambiguous spell IDs are handled
+	-- separately, and downstream/legacy parsers can normalize these few cases without
+	-- forcing fake spellings into the source log.
 	[10667] = "R.O.I.D.S.",
 	[57106] = "Medivh's Merlot",
 	[57107] = "Medivh's Merlot Blue",

--- a/format_log_for_upload.py
+++ b/format_log_for_upload.py
@@ -157,12 +157,22 @@ def replace_instances(player_entries, filename):
         # Create a single entry for all timestamps
         player_entries = [("00/00 00:00:00.000", player_name)]
 
-    # Mob names with apostrophes have top priority
-    # only the first match will be replaced
+    # Compatibility shim for the historical formatted output: keep the source log's
+    # exact apostrophized names, but normalize a few known labels back to the old
+    # upload spelling before the generic possessive parser rewrites them.
+    # Only the first match will be replaced.
     mob_names_with_apostrophe = {
         "Onyxia's Elite Guard": "Onyxias Elite Guard",
         "Sartura's Royal Guard": "Sarturas Royal Guard",
+        "Kreeg's Stout Beatdown": "Kreegs Stout Beatdown",
+        "Medivh's Merlot": "Medivhs Merlot",
+        "Medivh's Merlot Blue": "Medivhs Merlot Blue",
         "Medivh's Merlot Blue Label": "Medivhs Merlot Blue Label",
+        "Danonzo's Tel'Abim Delight": "Danonzos Tel'Abim Delight",
+        "Danonzo's Tel'Abim Medley": "Danonzos Tel'Abim Medley",
+        "Danonzo's Tel'Abim Surprise": "Danonzos Tel'Abim Surprise",
+        "Graccu's Homemade Meat Pie": "Graccus Homemade Meat Pie",
+        "Graccu's Mince Meat Fruitcake": "Graccus Mince Meat Fruitcake",
         "Ima'ghaol, Herald of Desolation": "Imaghaol, Herald of Desolation",
     }
 

--- a/tests/test_core.lua
+++ b/tests/test_core.lua
@@ -1,0 +1,384 @@
+local function containsPrefix(lines, prefix)
+    for _, line in ipairs(lines) do
+        if string.sub(line, 1, string.len(prefix)) == prefix then
+            return true
+        end
+    end
+    return false
+end
+
+local function containsText(lines, expected)
+    for _, line in ipairs(lines) do
+        if string.find(line, expected, 1, true) then
+            return true
+        end
+    end
+    return false
+end
+
+local function assertTrue(condition, message)
+    if not condition then
+        error(message)
+    end
+end
+
+local function makeItemLink(itemId, label)
+    return "|cff1eff00|Hitem:" .. tostring(itemId) .. ":0:0:0|h[" .. label .. "]|h|r"
+end
+
+local function newHarness(opts)
+    opts = opts or {}
+
+    local registered = {}
+    local onUpdate = nil
+    local logLines = {}
+    local zone = opts.zone or "Zul'Gurub"
+    local savedInstances = opts.savedInstances or {}
+    local inventory = opts.inventory or {}
+    local unitNames = opts.unitNames or {}
+    local unitExists = opts.unitExists or {}
+    local spellInfo = opts.spellInfo or {}
+
+    _G.SetAutoloot = true
+    _G.RPLL = nil
+    _G.UNKNOWN = "Unknown"
+    _G.UNKNOWNOBJECT = "Unknown"
+    _G.strlower = string.lower
+    _G.strlen = string.len
+    _G.StaticPopupDialogs = {}
+    _G.StaticPopup_Show = function() end
+    _G.TEXT = function(text) return text end
+    _G.OKAY = "OKAY"
+    _G.arg = nil
+
+    _G.CombatLogAdd = function(message)
+        table.insert(logLines, message)
+    end
+    _G.CombatLogFlush = opts.combatLogFlush or function() end
+    _G.LoggingCombat = function()
+        return nil
+    end
+    _G.GetTime = opts.getTime or function()
+        return 0
+    end
+    _G.time = opts.time or function()
+        return 0
+    end
+    _G.date = function()
+        return "01.01.26 00:00:00"
+    end
+    _G.GetRealZoneText = function()
+        return zone
+    end
+    _G.IsInInstance = opts.isInInstance or function()
+        return nil
+    end
+    _G.GetNumSavedInstances = function()
+        return #savedInstances
+    end
+    _G.GetSavedInstanceInfo = function(index)
+        local entry = savedInstances[index]
+        if not entry then
+            return nil
+        end
+        return entry.name, entry.id
+    end
+    _G.GetNumRaidMembers = opts.getNumRaidMembers or function()
+        return 0
+    end
+    _G.GetNumPartyMembers = opts.getNumPartyMembers or function()
+        return 0
+    end
+    _G.UnitInRaid = opts.unitInRaid or function()
+        return nil
+    end
+    _G.UnitInParty = opts.unitInParty or function()
+        return nil
+    end
+    _G.UnitAffectingCombat = opts.unitAffectingCombat or function()
+        return nil
+    end
+    _G.UnitIsGhost = opts.unitIsGhost or function()
+        return false
+    end
+    _G.UnitIsPlayer = opts.unitIsPlayer or function(unit)
+        return string.find(unit, "player", 1, true) == 1
+            or string.find(unit, "raid", 1, true) == 1
+            or string.find(unit, "party", 1, true) == 1
+    end
+    _G.UnitName = opts.unitName or function(unit)
+        return unitNames[unit]
+    end
+    _G.UnitExists = opts.unitExistsFn or function(unit)
+        local entry = unitExists[unit]
+        if entry == nil then
+            return nil, nil
+        end
+        if type(entry) == "table" then
+            return entry[1], entry[2]
+        end
+        return entry, nil
+    end
+    _G.GetGuildInfo = opts.getGuildInfo or function()
+        return nil
+    end
+    _G.UnitClass = opts.unitClass or function()
+        return "Warrior", "WARRIOR"
+    end
+    _G.UnitRace = opts.unitRace or function()
+        return "Human", "Human"
+    end
+    _G.UnitSex = opts.unitSex or function()
+        return 2
+    end
+    _G.GetInventoryItemLink = opts.getInventoryItemLink or function(unit, slot)
+        return inventory[unit] and inventory[unit][slot] or nil
+    end
+    _G.GetNumTalents = opts.getNumTalents or function()
+        return 0
+    end
+    _G.GetTalentInfo = opts.getTalentInfo or function()
+        return nil, nil, nil, nil, 0
+    end
+    _G.SpellInfo = opts.spellInfoFn or function(spellId)
+        local entry = spellInfo[spellId]
+        if type(entry) == "table" then
+            return entry[1], entry[2]
+        end
+        return entry
+    end
+
+    _G.CreateFrame = function(_, name)
+        local frame = { name = name }
+        function frame:RegisterEvent(eventName)
+            registered[eventName] = true
+        end
+        function frame:SetScript(scriptName, fn)
+            if scriptName == "OnUpdate" then
+                onUpdate = fn
+            elseif scriptName == "OnEvent" then
+                frame.onEvent = fn
+            end
+        end
+        return frame
+    end
+
+    _G.RPLL = CreateFrame("Frame", "RPLL")
+    dofile("core.lua")
+
+    return {
+        logLines = logLines,
+        registered = registered,
+        onUpdate = onUpdate,
+        rpll = _G.RPLL,
+        setZone = function(value)
+            zone = value
+        end,
+        setUnitName = function(unit, value)
+            unitNames[unit] = value
+        end,
+        setUnitExists = function(unit, exists, guid)
+            unitExists[unit] = { exists, guid }
+        end,
+        setInventory = function(unit, slot, value)
+            inventory[unit] = inventory[unit] or {}
+            inventory[unit][slot] = value
+        end,
+    }
+end
+
+local function dispatchHandler(ctx, name, ...)
+    _G.this = ctx.rpll
+    local handler = ctx.rpll[name]
+    return handler(...)
+end
+
+local function dispatchMethod(ctx, name, ...)
+    _G.this = ctx.rpll
+    return ctx.rpll[name](ctx.rpll, ...)
+end
+
+local function testRescansRaidRosterWhenHeadcountStaysFlat()
+    local ctx = newHarness({
+        getNumRaidMembers = function()
+            return 2
+        end,
+        unitNames = {
+            raid1 = "Alpha",
+            raid2 = "Bravo",
+        },
+        unitExists = {
+            raid1 = { true, "0xA" },
+            raid2 = { true, "0xB" },
+        },
+        inventory = {
+            raid1 = { [1] = makeItemLink(1001, "Helm A") },
+            raid2 = { [1] = makeItemLink(1002, "Helm B") },
+        },
+    })
+
+    dispatchHandler(ctx, "RAID_ROSTER_UPDATE")
+    ctx.setUnitName("raid2", "Charlie")
+    ctx.setUnitExists("raid2", true, "0xC")
+    ctx.setInventory("raid2", 1, makeItemLink(1003, "Helm C"))
+    dispatchHandler(ctx, "RAID_ROSTER_UPDATE")
+
+    assertTrue(containsText(ctx.logLines, "&Charlie&"), "expected same-count raid roster swap to log Charlie combatant info")
+end
+
+local function testRetriesCombatantInfoWhenFirstScanHasNoGear()
+    local now = 100
+    local ctx = newHarness({
+        time = function()
+            return now
+        end,
+        unitNames = {
+            raid1 = "Alpha",
+        },
+        unitExists = {
+            raid1 = { true, "0xA" },
+        },
+    })
+
+    dispatchMethod(ctx, "grab_unit_information", "raid1")
+    ctx.setInventory("raid1", 1, makeItemLink(1001, "Helm A"))
+    dispatchMethod(ctx, "grab_unit_information", "raid1")
+
+    assertTrue(containsText(ctx.logLines, "&Alpha&"), "expected second combatant scan to succeed after gear loads")
+end
+
+local function testEmitsOneAuthoritativeCastLinePerTrackedCast()
+    local ctx = newHarness({
+        unitNames = {
+            casterguid = "Warrior",
+            targetguid = "Target",
+        },
+        spellInfo = {
+            [11597] = { "Sunder Armor", "Rank 5" },
+        },
+    })
+
+    local before = #ctx.logLines
+    dispatchHandler(ctx, "UNIT_CASTEVENT", "casterguid", "targetguid", "CAST", 11597, 0)
+    local emitted = #ctx.logLines - before
+
+    assertTrue(emitted == 1, "expected one cast line for a tracked cast event")
+end
+
+local function testUsesAmbiguitySafeConsumeLabels()
+    local ctx = newHarness({
+        unitNames = {
+            casterguid = "Chef",
+        },
+    })
+
+    dispatchHandler(ctx, "UNIT_CASTEVENT", "casterguid", nil, "CAST", 24800, 0)
+
+    assertTrue(containsText(ctx.logLines, "Ambiguous"), "expected an ambiguity-safe consume label")
+    assertTrue(not containsText(ctx.logLines, "Power Mushroom"), "did not expect a guessed specific item label")
+end
+
+local function testPreservesExactUnambiguousConsumeLabels()
+    local ctx = newHarness({
+        unitNames = {
+            casterguid = "Chef",
+        },
+    })
+
+    dispatchHandler(ctx, "UNIT_CASTEVENT", "casterguid", nil, "CAST", 10667, 0)
+
+    assertTrue(containsText(ctx.logLines, "R.O.I.D.S."), "expected exact punctuation for unambiguous consume labels")
+    assertTrue(not containsText(ctx.logLines, "Rage of Ages"), "did not expect the old sanitized consume label")
+end
+
+local function testInitializesSpecialTargetsByZone()
+    local ctx = newHarness({
+        zone = "Blackwing Lair",
+        unitNames = {
+            bossguid = "Firemaw",
+            bossguidtarget = "Tank",
+        },
+        spellInfo = {
+            [22539] = { "Shadow Flame", "" },
+        },
+    })
+
+    dispatchHandler(ctx, "ZONE_CHANGED_NEW_AREA")
+    dispatchHandler(ctx, "UNIT_CASTEVENT", "bossguid", nil, "CAST", 22539, 0)
+
+    assertTrue(containsText(ctx.logLines, "on Tank"), "expected specials target enrichment to use the caster target in configured zones")
+end
+
+local function testNormalizesZoneInfoAliasesAndPreservesFallbackCase()
+    local ctx = newHarness({
+        zone = "Ahn'Qiraj Temple",
+        savedInstances = {
+            { name = "Temple of Ahn'Qiraj", id = 123 },
+        },
+    })
+
+    dispatchMethod(ctx, "QueueRaidIds")
+    assertTrue(containsText(ctx.logLines, "&Temple of Ahn'Qiraj&123"), "expected normalized ZONE_INFO match for AQ alias")
+
+    local fallbackCtx = newHarness({
+        zone = "Blackrock Spire",
+    })
+    dispatchMethod(fallbackCtx, "QueueRaidIds")
+    assertTrue(containsText(fallbackCtx.logLines, "&Blackrock Spire&0"), "expected fallback ZONE_INFO to preserve original case")
+end
+
+local function testBroadensTradeDetectionBeyondAsciiWordNames()
+    local ctx = newHarness()
+
+    dispatchHandler(ctx, "CHAT_MSG_SYSTEM", "René trades item Libram of the Faithful to Milkpress.")
+
+    assertTrue(containsPrefix(ctx.logLines, "LOOT_TRADE: "), "expected LOOT_TRADE for accented player names")
+end
+
+local function testUsesGuidCacheForUnitDied()
+    local ctx = newHarness({
+        unitNames = {
+            raid1 = "Alpha",
+        },
+        unitExists = {
+            raid1 = { true, "0xA" },
+        },
+        inventory = {
+            raid1 = { [1] = makeItemLink(1001, "Helm A") },
+        },
+        unitName = function(unit)
+            if unit == "raid1" then
+                return "Alpha"
+            end
+            return nil
+        end,
+    })
+
+    dispatchMethod(ctx, "grab_unit_information", "raid1")
+    dispatchHandler(ctx, "UNIT_DIED", "0xA")
+
+    assertTrue(containsText(ctx.logLines, "UNIT_DIED:Alpha:0xA"), "expected UNIT_DIED to resolve cached GUID names")
+end
+
+local function testDeepSubstringHandlesTailTokensCorrectly()
+    local ctx = newHarness()
+
+    local ok, result = pcall(function()
+        return dispatchMethod(ctx, "DeepSubString", "alpha beta", "betamax")
+    end)
+
+    assertTrue(ok, "expected DeepSubString tail-token matching not to error")
+    assertTrue(result == true, "expected DeepSubString to match against the final token")
+end
+
+testRescansRaidRosterWhenHeadcountStaysFlat()
+testRetriesCombatantInfoWhenFirstScanHasNoGear()
+testEmitsOneAuthoritativeCastLinePerTrackedCast()
+testUsesAmbiguitySafeConsumeLabels()
+testPreservesExactUnambiguousConsumeLabels()
+testInitializesSpecialTargetsByZone()
+testNormalizesZoneInfoAliasesAndPreservesFallbackCase()
+testBroadensTradeDetectionBeyondAsciiWordNames()
+testUsesGuidCacheForUnitDied()
+testDeepSubstringHandlesTailTokensCorrectly()
+print("ok - core.lua regression tests passed")

--- a/tests/test_format_log_for_upload.py
+++ b/tests/test_format_log_for_upload.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "format_log_for_upload.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("format_log_for_upload", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FormatLogForUploadTests(unittest.TestCase):
+    def test_restored_apostrophized_consume_names_normalize_to_legacy_output(self):
+        module = load_module()
+
+        contents = "\n".join(
+            [
+                "3/11 20:00:00.000  Chef uses Kreeg's Stout Beatdown.",
+                "3/11 20:00:01.000  Chef uses Medivh's Merlot.",
+                "3/11 20:00:02.000  Chef uses Medivh's Merlot Blue.",
+                "3/11 20:00:03.000  Chef uses Danonzo's Tel'Abim Delight.",
+                "3/11 20:00:04.000  Chef uses Danonzo's Tel'Abim Medley.",
+                "3/11 20:00:05.000  Chef uses Danonzo's Tel'Abim Surprise.",
+                "3/11 20:00:06.000  Chef uses Graccu's Homemade Meat Pie.",
+                "3/11 20:00:07.000  Chef uses Graccu's Mince Meat Fruitcake.",
+                "",
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = pathlib.Path(tmpdir) / "WoWCombatLog.txt"
+            log_path.write_text(contents, encoding="utf-8")
+
+            module.replace_instances([("3/11 19:59:59.000", "Chef")], str(log_path))
+
+            rewritten = log_path.read_text(encoding="utf-8")
+
+        self.assertIn("Kreegs Stout Beatdown", rewritten)
+        self.assertIn("Medivhs Merlot", rewritten)
+        self.assertIn("Medivhs Merlot Blue", rewritten)
+        self.assertIn("Danonzos Tel'Abim Delight", rewritten)
+        self.assertIn("Danonzos Tel'Abim Medley", rewritten)
+        self.assertIn("Danonzos Tel'Abim Surprise", rewritten)
+        self.assertIn("Graccus Homemade Meat Pie", rewritten)
+        self.assertIn("Graccus Mince Meat Fruitcake", rewritten)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR:
  - Improves logger accuracy in core.lua:
      - rescan raid rosters by roster identity, not just headcount
      - retry COMBATANT_INFO when the first scan lands before gear data is available
      - use cached GUID-to-name data for UNIT_DIED
      - fix strsplit() tail handling
      - normalize ZONE_INFO aliases while preserving fallback display casing
      - broaden trade detection beyond %w-only names
      - initialize zone-specific specials target enrichment correctly
  - Makes cast and consume output more truthful:
      - remove duplicate V1+V2 cast emission by making the richer cast path authoritative
      - emit ambiguity-safe labels for consume spell IDs that map to multiple items
      - keep exact punctuation for unique item names in the source log
  - Preserves compatibility with historical formatted output in format_log_for_upload.py by normalizing the restored
    apostrophized consume labels back to the legacy upload spelling before generic possessive parsing runs
  - Adds regression coverage for both the Lua logger and the Python formatter

  Test Plan

  - lua tests/test_core.lua
  - python3 tests/test_format_log_for_upload.py